### PR TITLE
Support different classes with same name in same static factory class, closes #9

### DIFF
--- a/srcless-processors/src/main/java/org/dmfs/srcless/processors/staticfactory/ClassCtor.java
+++ b/srcless-processors/src/main/java/org/dmfs/srcless/processors/staticfactory/ClassCtor.java
@@ -72,6 +72,13 @@ class ClassCtor implements AnnotatedCtor
 
 
             @Override
+            public String fqClass()
+            {
+                return mClassElement.getQualifiedName().toString();
+            }
+
+
+            @Override
             public boolean hasModifier(Modifier modifier)
             {
                 return mCtorElement.getModifiers().contains(modifier);

--- a/srcless-processors/src/main/java/org/dmfs/srcless/processors/staticfactory/CtorDescription.java
+++ b/srcless-processors/src/main/java/org/dmfs/srcless/processors/staticfactory/CtorDescription.java
@@ -14,6 +14,8 @@ public interface CtorDescription
 {
     String name();
 
+    String fqClass();
+
     boolean hasModifier(Modifier modifier);
 
     Iterable<? extends TypeMirror> thrownExceptions();

--- a/srcless-processors/src/main/java/org/dmfs/srcless/processors/staticfactory/LombokAllArgsCtor.java
+++ b/srcless-processors/src/main/java/org/dmfs/srcless/processors/staticfactory/LombokAllArgsCtor.java
@@ -74,6 +74,13 @@ public final class LombokAllArgsCtor implements AnnotatedCtor
 
 
             @Override
+            public String fqClass()
+            {
+                return mClassElement.getQualifiedName().toString();
+            }
+
+
+            @Override
             public boolean hasModifier(Modifier modifier)
             {
                 // we only handle public ctors

--- a/srcless-processors/src/main/java/org/dmfs/srcless/processors/staticfactory/StaticFactoryProcessor.java
+++ b/srcless-processors/src/main/java/org/dmfs/srcless/processors/staticfactory/StaticFactoryProcessor.java
@@ -121,7 +121,7 @@ public final class StaticFactoryProcessor extends AbstractProcessor
                         .build(),
                     ctorDescription.parameters()))
                 .addStatement("return new $1L$2L($3L)",
-                    ctorDescription.name(),
+                    ctorDescription.fqClass(),
                     ctor.clazz().getTypeParameters().isEmpty() ? "" : "<>",
                     String.join(", ", new Mapped<>(VariableElement::getSimpleName, ctorDescription.parameters())));
 

--- a/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/AllArgsFactoryExpected.java
+++ b/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/AllArgsFactoryExpected.java
@@ -13,7 +13,7 @@ public final class Factory
 
     public static AllArgsFactory allArgsFactory(@Nonnull String s, int i)
     {
-        return new AllArgsFactory(s, i);
+        return new org.dmfs.srcless.staticfactory.AllArgsFactory(s, i);
     }
 
 }

--- a/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/AnnotatedFactoryExpected.java
+++ b/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/AnnotatedFactoryExpected.java
@@ -16,14 +16,14 @@ public final class Factory
     @SafeVarargs
     public static AnnotatedFactory annotatedFactory(Object... o)
     {
-        return new AnnotatedFactory(o);
+        return new org.dmfs.srcless.staticfactory.AnnotatedFactory(o);
     }
 
 
     @SuppressWarnings("unchecked")
     public static AnnotatedFactory annotatedFactory(String s)
     {
-        return new AnnotatedFactory(s);
+        return new org.dmfs.srcless.staticfactory.AnnotatedFactory(s);
     }
 
 }

--- a/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/DefaultFactoryExpected.java
+++ b/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/DefaultFactoryExpected.java
@@ -10,6 +10,6 @@ public final class Factory
 
     public static DefaultFactory defaultFactory()
     {
-        return new DefaultFactory();
+        return new org.dmfs.srcless.staticfactory.DefaultFactory();
     }
 }

--- a/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/GenericCtorFactoryExpected.java
+++ b/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/GenericCtorFactoryExpected.java
@@ -10,6 +10,6 @@ public final class Factory
 
     public static <W> GenericCtorFactory genericCtorFactory(W w)
     {
-        return new GenericCtorFactory(w);
+        return new org.dmfs.srcless.staticfactory.GenericCtorFactory(w);
     }
 }

--- a/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/GenericFactoryExpected.java
+++ b/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/GenericFactoryExpected.java
@@ -10,13 +10,13 @@ public final class Factory
 
     public static <U, V, W> GenericFactory<U, V> genericFactory(U u, V v, W w)
     {
-        return new GenericFactory<>(u, v, w);
+        return new org.dmfs.srcless.staticfactory.GenericFactory<>(u, v, w);
     }
 
 
     public static <U, V> GenericFactory<U, V> genericFactory(U u, V v)
     {
-        return new GenericFactory<>(u, v);
+        return new org.dmfs.srcless.staticfactory.GenericFactory<>(u, v);
     }
 
 }

--- a/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/SoleFactoryExpected.java
+++ b/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/SoleFactoryExpected.java
@@ -12,7 +12,7 @@ public final class Factory
 
     public static SoleFactory soleFactory(String s)
     {
-        return new SoleFactory(s);
+        return new org.dmfs.srcless.staticfactory.SoleFactory(s);
     }
 }
 

--- a/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/ThrowingFactoryExpected.java
+++ b/srcless-processors/src/test/resources/org/dmfs/srcless/staticfactory/ThrowingFactoryExpected.java
@@ -13,7 +13,7 @@ public final class Factory
 
     public static ThrowingFactory throwingFactory(String s) throws IOException
     {
-        return new ThrowingFactory(s);
+        return new org.dmfs.srcless.staticfactory.ThrowingFactory(s);
     }
 }
 


### PR DESCRIPTION
Now multiple classes from different packages with the same name can be added as long as they have different signatures.